### PR TITLE
[Feature/#9] 유형별 주택 시세 확인 UI 구현 및 BFF API 연결

### DIFF
--- a/src/app/bff/routes/rent.routes.ts
+++ b/src/app/bff/routes/rent.routes.ts
@@ -155,7 +155,7 @@ export async function rentRoutes(app: FastifyInstance) {
     },
   });
 
-  app.get("/rent/multiHousehold", {
+  app.get("/rent/multi-household", {
     schema: {
       tags: ["Rents"],
       response: {
@@ -257,7 +257,7 @@ export async function rentRoutes(app: FastifyInstance) {
               district: String(item.umdNm),
             },
             contract: {
-              date: `${item.dealYear}${item.dealMonth}${item.dealDay}`,
+              date: `${item.dealYear}.${item.dealMonth}.${item.dealDay}`,
               term: String(item.contractTerm),
               type: String(item.contractType),
             },
@@ -282,7 +282,7 @@ export async function rentRoutes(app: FastifyInstance) {
               )}`,
             },
             contract: {
-              date: `${item.dealYear}${item.dealMonth}${item.dealDay}`,
+              date: `${item.dealYear}.${item.dealMonth}.${item.dealDay}`,
               term: String(item.contractTerm),
               type: String(item.contractType),
             },
@@ -305,7 +305,7 @@ export async function rentRoutes(app: FastifyInstance) {
               district: `${String(item.umdNm)} ${String(item.jibun)}`,
             },
             contract: {
-              date: `${item.dealYear}${item.dealMonth}${item.dealDay}`,
+              date: `${item.dealYear}.${item.dealMonth}.${item.dealDay}`,
               term: String(item.contractTerm),
               type: String(item.contractType),
             },
@@ -329,18 +329,12 @@ export async function rentRoutes(app: FastifyInstance) {
               district: `${String(item.umdNm)} ${String(item.jibun)}`,
             },
             contract: {
-              date: `${item.dealYear}${item.dealMonth}${item.dealDay}`,
+              date: `${item.dealYear}.${item.dealMonth}.${item.dealDay}`,
               term: String(item.contractTerm),
               type: String(item.contractType),
             },
           }));
 
-        console.log(
-          transformedSingleMultiFamily,
-          transformedOfficetel,
-          transformedApartment,
-          transformedMultiHousehold
-        );
         // ✅ 모든 데이터를 하나의 JSON 객체로 응답
         res.send({
           singleMultiFamily: transformedSingleMultiFamily,

--- a/src/app/bff/routes/rent.routes.ts
+++ b/src/app/bff/routes/rent.routes.ts
@@ -7,6 +7,7 @@ import {
 } from "../schemas/rent.schema";
 import { RentService } from "../services/rent.service";
 import {
+  FrontendRentApartment,
   FrontendRentMultiHousehold,
   FrontendRentOfficetel,
   FrontendRentSingleMultiFamily,
@@ -121,7 +122,7 @@ export async function rentRoutes(app: FastifyInstance) {
           "apartment"
         )) as RentApartmentResponse;
 
-        const transformedData: FrontendRentOfficetel[] =
+        const transformedData: FrontendRentApartment[] =
           rawData.data.items.item.map((item, index) => ({
             id: `${item.dealYear}${item.dealMonth}${item.dealDay}-${index + 1}`,
             buildingInfo: {
@@ -190,7 +191,163 @@ export async function rentRoutes(app: FastifyInstance) {
               type: item.contractType,
             },
           }));
+        console.log(transformedData);
         res.send(transformedData);
+      } catch (error) {
+        console.error("API Error:", error);
+        res
+          .status(500)
+          .send({ error: `외부 API 호출에 실패했습니다. ${error}` });
+      }
+    },
+  });
+
+  app.get("/rent/all", {
+    schema: {
+      tags: ["Rents"],
+      response: {
+        200: {
+          type: "object",
+          properties: {
+            singleMultiFamily: rentResponseSingleMultiFamilySchema,
+            officetel: rentResponseOfficetelSchema,
+            apartment: rentResponseApartmentSchema,
+            multiHousehold: rentResponseMultiHouseHoldSchema,
+          },
+        },
+      },
+    },
+    handler: async (req, res) => {
+      try {
+        // 🔥 병렬 요청으로 모든 데이터 가져오기
+        const [
+          singleMultiFamilyData,
+          officetelData,
+          apartmentData,
+          multiHouseholdData,
+        ] = await Promise.all([
+          RentService.getRentDatatype(
+            "singleMultiFamily"
+          ) as Promise<RentSingleMultiFamilyResponse>,
+          RentService.getRentDatatype(
+            "officetel"
+          ) as Promise<RentOfficetelResponse>,
+          RentService.getRentDatatype(
+            "apartment"
+          ) as Promise<RentApartmentResponse>,
+          RentService.getRentDatatype(
+            "multiHousehold"
+          ) as Promise<RentMultiHouseholdResponse>,
+        ]);
+        // console.log(singleMultiFamilyData.data.items.item);
+
+        const transformedSingleMultiFamily: FrontendRentSingleMultiFamily[] =
+          singleMultiFamilyData.data.items.item.map((item, index) => ({
+            id: `${item.dealYear}${item.dealMonth}${item.dealDay}-${index + 1}`,
+            buildingInfo: {
+              type: String(item.houseType), // 이미 string이지만, 확실히 하기 위해 변환
+              area: String(item.totalFloorAr),
+              year: String(item.buildYear),
+            },
+            price: {
+              deposit: String(item.deposit),
+              monthlyRent: String(item.monthlyRent),
+            },
+            location: {
+              district: String(item.umdNm),
+            },
+            contract: {
+              date: `${item.dealYear}${item.dealMonth}${item.dealDay}`,
+              term: String(item.contractTerm),
+              type: String(item.contractType),
+            },
+          }));
+
+        const transformedOfficetel: FrontendRentOfficetel[] =
+          officetelData.data.items.item.map((item, index) => ({
+            id: `${item.dealYear}${item.dealMonth}${item.dealDay}-${index + 1}`,
+            buildingInfo: {
+              name: String(item.offiNm),
+              area: String(item.excluUseAr),
+              floor: String(item.floor),
+              year: String(item.buildYear),
+            },
+            price: {
+              deposit: String(item.deposit),
+              monthlyRent: String(item.monthlyRent),
+            },
+            location: {
+              district: `${String(item.sggNm)} ${String(item.umdNm)} ${String(
+                item.jibun
+              )}`,
+            },
+            contract: {
+              date: `${item.dealYear}${item.dealMonth}${item.dealDay}`,
+              term: String(item.contractTerm),
+              type: String(item.contractType),
+            },
+          }));
+
+        const transformedApartment: FrontendRentApartment[] =
+          apartmentData.data.items.item.map((item, index) => ({
+            id: `${item.dealYear}${item.dealMonth}${item.dealDay}-${index + 1}`,
+            buildingInfo: {
+              name: String(item.aptNm),
+              area: String(item.excluUseAr),
+              floor: String(item.floor),
+              year: String(item.buildYear),
+            },
+            price: {
+              deposit: String(item.deposit),
+              monthlyRent: String(item.monthlyRent),
+            },
+            location: {
+              district: `${String(item.umdNm)} ${String(item.jibun)}`,
+            },
+            contract: {
+              date: `${item.dealYear}${item.dealMonth}${item.dealDay}`,
+              term: String(item.contractTerm),
+              type: String(item.contractType),
+            },
+          }));
+
+        const transformedMultiHousehold: FrontendRentMultiHousehold[] =
+          multiHouseholdData.data.items.item.map((item, index) => ({
+            id: `${item.dealYear}${item.dealMonth}${item.dealDay}-${index + 1}`,
+            buildingInfo: {
+              type: String(item.houseType),
+              name: String(item.mhouseNm),
+              area: String(item.excluUseAr),
+              floor: String(item.floor),
+              year: String(item.buildYear),
+            },
+            price: {
+              deposit: String(item.deposit),
+              monthlyRent: String(item.monthlyRent),
+            },
+            location: {
+              district: `${String(item.umdNm)} ${String(item.jibun)}`,
+            },
+            contract: {
+              date: `${item.dealYear}${item.dealMonth}${item.dealDay}`,
+              term: String(item.contractTerm),
+              type: String(item.contractType),
+            },
+          }));
+
+        console.log(
+          transformedSingleMultiFamily,
+          transformedOfficetel,
+          transformedApartment,
+          transformedMultiHousehold
+        );
+        // ✅ 모든 데이터를 하나의 JSON 객체로 응답
+        res.send({
+          singleMultiFamily: transformedSingleMultiFamily,
+          officetel: transformedOfficetel,
+          apartment: transformedApartment,
+          multiHousehold: transformedMultiHousehold,
+        });
       } catch (error) {
         console.error("API Error:", error);
         res

--- a/src/app/bff/types/rent,types.ts
+++ b/src/app/bff/types/rent,types.ts
@@ -99,36 +99,6 @@ export type RentSingleMultiFamilyResponse =
   RentResponse<RentSingleMultiFamilyItem>;
 export type RentMultiHouseholdResponse = RentResponse<RentMultiHouseholdItem>;
 
-export interface FrontenRent {
-  id: string;
-  buildingInfo: {
-    type: string;
-    area: string;
-  };
-  price: {
-    deposit: string;
-    monthlyRent: string;
-  };
-  location: {
-    district: string;
-  };
-}
-
-export interface FrontendRent {
-  id: string;
-  buildingInfo: {
-    type: string; // houseType
-    area: string; //totalFloorAr
-  };
-  price: {
-    deposit: string; //deposit
-    monthlyRent: string; //monthlyRent
-  };
-  location: {
-    district: string; //umdNm
-  };
-}
-
 export interface FrontendRentBase {
   id: string;
   price: {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 export default function Home() {
   return (
     <div className="flex flex-col items-center justify-center h-screen">
-      <h1 className="text-3xl font-bold mb-4">내집구함</h1>
+      <h1 className="text-3xl font-bold mb-4">내집구함🔍</h1>
       <p className="text-gray-700 font-bold mb-6">
         이 넓은 서울 땅에 내 집 하나는 있겠지!
       </p>
@@ -11,7 +11,7 @@ export default function Home() {
       {/* ✅ listing 페이지로 이동하는 버튼 */}
       <Link href="/rent">
         <button className="px-6 py-3 bg-indigo-500 text-white rounded-lg shadow-md hover:bg-indigo-600 transition">
-          내집(후보) 시세 확인하기
+          🏡 내집(후보) 시세 확인하기
         </button>
       </Link>
       <br />

--- a/src/app/rent/modules/CommonRentItem.tsx
+++ b/src/app/rent/modules/CommonRentItem.tsx
@@ -1,0 +1,19 @@
+import { FrontendRentBase } from "@/app/bff/types/rent,types";
+
+interface Props {
+  rent: FrontendRentBase;
+  children?: React.ReactNode; // 특정 유형에 대한 추가 UI
+}
+
+export default function CommonRentItem({ rent, children }: Props) {
+  return (
+    <li className="border p-4 rounded-lg shadow">
+      <h3 className="text-xl font-semibold">{rent.location.district}</h3>
+      <h3 className="text-lg font-semibold">
+        💰 월세: {rent.price.monthlyRent} / 보증금: {rent.price.deposit}
+      </h3>
+      {children} {/* 개별 속성 UI 삽입 */}
+      <p>📅 계약일: {rent.contract.date}</p>
+    </li>
+  );
+}

--- a/src/app/rent/modules/SpecificRentDetails.tsx
+++ b/src/app/rent/modules/SpecificRentDetails.tsx
@@ -1,0 +1,67 @@
+import {
+  FrontendRentApartment,
+  FrontendRentMultiHousehold,
+  FrontendRentOfficetel,
+  FrontendRentSingleMultiFamily,
+  RentType,
+} from "@/app/bff/types/rent,types";
+
+interface Props {
+  rent:
+    | FrontendRentSingleMultiFamily
+    | FrontendRentMultiHousehold
+    | FrontendRentOfficetel
+    | FrontendRentApartment;
+  type: RentType;
+}
+
+export default function SpecificRentDetails({ rent, type }: Props) {
+  if (type === "singleMultiFamily") {
+    const specificRent = rent as FrontendRentSingleMultiFamily;
+    return (
+      <div>
+        <h3 className="text-lg font-medium">
+          🏠 {specificRent.buildingInfo.type} ({specificRent.buildingInfo.area}
+          ㎡)
+        </h3>
+      </div>
+    );
+  }
+  if (type === "officetel") {
+    const specificRent = rent as FrontendRentOfficetel;
+    return (
+      <div>
+        <h3 className="text-lg font-medium">
+          🏢 {specificRent.buildingInfo.name} {specificRent.buildingInfo.floor}
+          층 ({specificRent.buildingInfo.area}㎡, )
+        </h3>
+      </div>
+    );
+  }
+  if (type === "apartment") {
+    const specificRent = rent as FrontendRentApartment;
+    return (
+      <div>
+        <h3 className="text-lg font-medium">
+          🌆 {specificRent.buildingInfo.name} {specificRent.buildingInfo.floor}
+          층 ({specificRent.buildingInfo.area}
+          ㎡)
+        </h3>
+      </div>
+    );
+  }
+  if (type === "multiHousehold") {
+    const specificRent = rent as FrontendRentMultiHousehold;
+    return (
+      <div>
+        <h3 className="text-lg font-medium">
+          🌇 {specificRent.buildingInfo.name} {specificRent.buildingInfo.floor}
+          층 ({specificRent.buildingInfo.area}
+          ㎡)
+        </h3>
+      </div>
+    );
+  }
+
+  return null;
+}

--- a/src/app/rent/page.tsx
+++ b/src/app/rent/page.tsx
@@ -1,70 +1,91 @@
 "use client";
-
-import Link from "next/link";
-import { useEffect, useState } from "react";
-import { FrontendRentSingleMultiFamily } from "../bff/types/rent,types";
+import { useState, useEffect } from "react";
+import CommonRentItem from "./modules/CommonRentItem";
+import SpecificRentDetails from "./modules/SpecificRentDetails";
+import {
+  FrontendRentSingleMultiFamily,
+  FrontendRentOfficetel,
+  FrontendRentApartment,
+  FrontendRentMultiHousehold,
+} from "../bff/types/rent,types";
+const API_URL = "http://localhost:5000/rent/all";
 
 export default function RentPage() {
-  const [estates, setEstates] = useState<FrontendRentSingleMultiFamily[]>([]);
+  type RentData = {
+    singleMultiFamily: FrontendRentSingleMultiFamily[];
+    officetel: FrontendRentOfficetel[];
+    apartment: FrontendRentApartment[];
+    multiHousehold: FrontendRentMultiHousehold[];
+  };
+
+  const [data, setData] = useState<RentData>({
+    singleMultiFamily: [],
+    officetel: [],
+    apartment: [],
+    multiHousehold: [],
+  });
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [selectedType, setSelectedType] =
+    useState<keyof RentData>("singleMultiFamily");
 
   useEffect(() => {
-    const fetchEstates = async () => {
+    const fetchData = async () => {
       try {
-        const response = await fetch(
-          "http://localhost:5000/rent/single-multi-family"
-        );
-        if (!response.ok) {
-          throw new Error("네트워크 응답이 실패했습니다");
-        }
-        const data: FrontendRentSingleMultiFamily[] = await response.json();
-        setEstates(data);
-      } catch (error) {
-        setError("데이터를 가져오는 중 문제가 발생했습니다.");
-        console.error("API 요청 실패:", error);
+        const response = await fetch(API_URL);
+        if (!response.ok) throw new Error("네트워크 오류");
+        const result = await response.json();
+        setData(result);
+      } catch (err) {
+        setError(`데이터를 불러오는 중 오류가 발생했습니다.: ${err}`);
       } finally {
         setLoading(false);
       }
     };
-
-    fetchEstates();
+    fetchData();
   }, []);
 
-  if (loading) {
-    return <p>데이터를 불러오는 중...</p>;
-  }
+  if (loading) return <p>데이터를 불러오는 중...</p>;
+  if (error) return <p className="text-red-500">{error}</p>;
 
-  if (error) {
-    return <p className="text-red-500">{error}</p>;
-  }
+  const categories = {
+    singleMultiFamily: "단독/다가구",
+    officetel: "오피스텔",
+    apartment: "아파트",
+    multiHousehold: "다세대주택",
+  };
+
+  const rents = data[selectedType as keyof RentData];
 
   return (
     <div className="p-4">
       <h2 className="text-2xl font-bold mb-4">내집(이 될 예정😏) 시세 🏠</h2>
-      {estates.length === 0 ? (
+
+      {/* 탭 버튼 */}
+      <div className="flex gap-4 mb-4">
+        {Object.keys(categories).map((key) => (
+          <button
+            key={key}
+            className={`px-4 py-2 rounded-lg ${
+              selectedType === key ? "bg-blue-500 text-white" : "bg-gray-200"
+            }`}
+            onClick={() => setSelectedType(key as keyof RentData)}
+          >
+            {categories[key as keyof typeof categories]}
+          </button>
+        ))}
+      </div>
+
+      {/* 선택한 타입의 부동산 데이터 표시 */}
+      {rents.length === 0 ? (
         <p>데이터가 없습니다.</p>
       ) : (
-        <ul className="space-y-4">
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            {estates.map((estate) => (
-              <Link key={estate.id} href={`/rent/${estate.id}`}>
-                <li key={estate.id} className="border p-4 rounded-lg shadow">
-                  <h3 className="text-xl font-semibold">
-                    {estate.location.district}
-                  </h3>
-                  <h3 className="text-lg font-medium">
-                    💰 월세: {estate.price.monthlyRent} / 보증금:{" "}
-                    {estate.price.deposit}
-                  </h3>
-                  <h3 className="text-lg font-medium">
-                    🛏️ 면적: {estate.buildingInfo.area}㎡ (
-                    {estate.buildingInfo.type})
-                  </h3>
-                </li>
-              </Link>
-            ))}
-          </div>
+        <ul className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          {rents.map((rent) => (
+            <CommonRentItem key={rent.id} rent={rent}>
+              <SpecificRentDetails rent={rent} type={selectedType} />
+            </CommonRentItem>
+          ))}
         </ul>
       )}
     </div>


### PR DESCRIPTION

![chrome-capture-2025-2-15 (1)](https://github.com/user-attachments/assets/10edf337-f159-4dc3-a475-6935fbcafed5)


오피스텔, 아파트, 연립다세대, 단독/다가구 별로 확인할 수 있도록 탭을 구현했습니다. + 전체보기 탭 구현했습니다.